### PR TITLE
Add from support for the setters

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "128"]
+
 #[macro_use]
 extern crate bitfield;
 


### PR DESCRIPTION
This PR adds the ability for setters to take a type to convert back into an u32. 

`u32, from into FooBar, field4, set_field4: 10, 0; `

will generate the following setter:

```rust
fn set_field4(&mut self, value: FooBar) {
    use bitfield::BitRange;
    self.set_bit_range(10, 0, bitfield::Into::<u32>::into(value));
}
```

This allows making more uniform APIs to access fields.