### PR TITLE
Add bitmask generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,11 @@
 ///     // `field4` will be read as an `u32` and then converted to `FooBar`.
 ///     // The setter will take a `FooBar`, and converted back to an `u32`.
 ///     u32, from into FooBar, field4, set_field4: 10, 0;
+///     // `field5` will be read as an `u32` and then converted to `FooBar`.
+///     // The setter will take a `FooBar`, and converted back to an `u32`.
+///     // The struct will have an associated constant `FIELD5_MASK` of type u64
+///     //with the bits of field5 set
+///     u32, mask FIELD5_MASK(u64), from into FooBar, field5, set_field5: 10, 0;
 /// }
 /// # }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,40 @@ macro_rules! bitfield_fields {
     (only $only:tt; $default_ty:ty; ($(#[$attributes:meta])*) #[$attribute:meta] $($rest:tt)*) => {
         bitfield_fields!{only $only; $default_ty; ($(#[$attributes])* #[$attribute]) $($rest)*}
     };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub $t:ty, mask $mask:ident($mask_t:ty), from into $into:ty, $getter:tt, $setter:tt:
+     $($exprs:expr),*; $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $t, $mask($mask_t), $into, $into, $getter, $setter: $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub $t:ty, mask $mask:ident($mask_t:ty), into $into:ty, $getter:tt, $setter:tt:
+     $($exprs:expr),*; $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $t, $mask($mask_t), $t, $into, $getter, $setter: $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub $t:ty, mask $mask:ident($mask_t:ty), $getter:tt, $setter:tt:  $($exprs:expr),*;
+     $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $t, $mask($mask_t), $t, $t, $getter, $setter: $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub mask $mask:ident($mask_t:ty), from into $into:ty, $getter:tt, $setter:tt:
+     $($exprs:expr),*; $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $default_ty, $mask($mask_t), $into, $into, $getter, $setter:
+                         $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub mask $mask:ident($mask_t:ty), into $into:ty, $getter:tt, $setter:tt:
+     $($exprs:expr),*; $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $default_ty, $mask($mask_t), $default_ty, $into, $getter, $setter:
+                         $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+    (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub mask $mask:ident($mask_t:ty), $getter:tt, $setter:tt:  $($exprs:expr),*;
+     $($rest:tt)*) => {
+        bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $default_ty, $mask($mask_t), $default_ty, $default_ty, $getter, $setter:
+                                $($exprs),*}
+        bitfield_fields!{only $only; $default_ty; $($rest)*}
+    };
+
     (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) pub $t:ty, from into $into:ty, $getter:tt, $setter:tt:
      $($exprs:expr),*; $($rest:tt)*) => {
         bitfield_fields!{only $only; @field $(#[$attribute])* (pub) $t, __NO_MASK_FOR_FIELD(u8), $into, $into, $getter, $setter: $($exprs),*}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -40,12 +40,12 @@ bitfield! {
     foo5, set_foo5: 0, 0, 32;
     u32;
     foo6, set_foo6: 5, THREE, THREE;
-    getter_only, _: 3, 1;
-    _, setter_only: 2*2, 2;
+    mask GETTER_MASK(u32), getter_only, _: 3, 1;
+    mask SETTER_MASK(u32), _, setter_only: 2*2, 2;
     getter_only_array, _: 5, 3, 3;
     _, setter_only_array: 2*THREE, 4, 3;
     all_bits, set_all_bits: 31, 0;
-    single_bit, set_single_bit: 3;
+    mask SINGLE_BIT_MASK(u32), single_bit, set_single_bit: 3;
     u8, into Foo, into_foo1, set_into_foo1: 31, 31;
     pub u8, into Foo, into_foo2, set_into_foo2: 31, 31;
     u8, from into Foo, from_foo1, set_from_foo1: 31, 31;
@@ -64,8 +64,8 @@ bitfield! {
     signed_two_bits, set_signed_two_bits: 1, 0;
     signed_eight_bits, set_signed_eight_bits: 7, 0;
     signed_eight_bits_unaligned, set_signed_eight_bits_unaligned: 8, 1;
-    u128, u128_getter, set_u128: 8, 1;
-    i128, i128_getter, set_i128: 8, 1;
+    u128, mask U128_MASK(u128), u128_getter, set_u128: 8, 1;
+    i128, mask I128_MASK(i128), i128_getter, set_i128: 8, 1;
 }
 
 impl FooBar {
@@ -808,7 +808,6 @@ fn field_can_be_public() {
 #[allow(dead_code)]
 mod test_types {
     use bitfield::{BitRange, BitRangeMut};
-    use std;
     use std::sync::atomic::{self, AtomicUsize};
 
     struct Foo;
@@ -910,6 +909,8 @@ mod test_no_default_bitrange {
     use std::fmt::Debug;
     use std::fmt::Error;
     use std::fmt::Formatter;
+
+    use crate::FooBar;
     bitfield! {
       #[derive(Eq, PartialEq)]
       pub struct BitField1(u16);
@@ -1135,5 +1136,14 @@ mod test_no_default_bitrange {
         format!("{:?}", BitField6([0; 1]));
         format!("{:?}", BitField7([0; 1]));
         format!("{:?}", BitField9([0; 1]));
+    }
+
+    #[test]
+    fn masks() {
+        assert_eq!(FooBar::I128_MASK, 0b111111110i128);
+        assert_eq!(FooBar::U128_MASK, 0b111111110u128);
+        assert_eq!(FooBar::SETTER_MASK, 0b11100u32);
+        assert_eq!(FooBar::GETTER_MASK, 0b1110u32);
+        assert_eq!(FooBar::SINGLE_BIT_MASK, 1 << 3);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,12 +42,14 @@ bitfield! {
     foo6, set_foo6: 5, THREE, THREE;
     mask GETTER_MASK(u32), getter_only, _: 3, 1;
     mask SETTER_MASK(u32), _, setter_only: 2*2, 2;
+    pub mask PUB_GETTER_MASK(u32), pub_getter_only, _: 3, 1;
+    pub mask PUB_SETTER_MASK(u32), _, pub_setter_only: 2*2, 2;
     getter_only_array, _: 5, 3, 3;
     _, setter_only_array: 2*THREE, 4, 3;
     all_bits, set_all_bits: 31, 0;
     mask SINGLE_BIT_MASK(u32), single_bit, set_single_bit: 3;
     u8, into Foo, into_foo1, set_into_foo1: 31, 31;
-    pub u8, into Foo, into_foo2, set_into_foo2: 31, 31;
+    pub u8, mask PUB_MASK(u32), into Foo, into_foo2, set_into_foo2: 31, 31;
     u8, from into Foo, from_foo1, set_from_foo1: 31, 31;
     u8, from into Foo, _, set_from_foo2: 31, 31;
     u8;
@@ -470,7 +472,7 @@ fn test_is_copy() {
 #[test]
 fn test_debug() {
     let fb = FooBar(1_234_567_890);
-    let expected = "FooBar { .0: 1234567890, foo1: 0, foo2: 0, foo3: 2, foo3: 2, foo4: 4, foo5: [0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0], foo6: [2, 3, 1], getter_only: 1, getter_only_array: [2, 3, 1], all_bits: 1234567890, single_bit: false, into_foo1: Foo(0), into_foo2: Foo(0), from_foo1: Foo(0), into_foo3: Foo(0), into_foo4: Foo(0), into_foo6: [Foo(0), Foo(1), Foo(0)], from_foo3: Foo(0), from_foo5: [Foo(0), Foo(1), Foo(0)], from_foo6: Foo(0), signed_single_bit: 0, signed_two_bits: -2, signed_eight_bits: -46, signed_eight_bits_unaligned: 105, u128_getter: 105, i128_getter: 105 }";
+    let expected = "FooBar { .0: 1234567890, foo1: 0, foo2: 0, foo3: 2, foo3: 2, foo4: 4, foo5: [0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0], foo6: [2, 3, 1], getter_only: 1, pub_getter_only: 1, getter_only_array: [2, 3, 1], all_bits: 1234567890, single_bit: false, into_foo1: Foo(0), into_foo2: Foo(0), from_foo1: Foo(0), into_foo3: Foo(0), into_foo4: Foo(0), into_foo6: [Foo(0), Foo(1), Foo(0)], from_foo3: Foo(0), from_foo5: [Foo(0), Foo(1), Foo(0)], from_foo6: Foo(0), signed_single_bit: 0, signed_two_bits: -2, signed_eight_bits: -46, signed_eight_bits_unaligned: 105, u128_getter: 105, i128_getter: 105 }";
     assert_eq!(expected, format!("{:?}", fb))
 }
 
@@ -1144,6 +1146,9 @@ mod test_no_default_bitrange {
         assert_eq!(FooBar::U128_MASK, 0b111111110u128);
         assert_eq!(FooBar::SETTER_MASK, 0b11100u32);
         assert_eq!(FooBar::GETTER_MASK, 0b1110u32);
+        assert_eq!(FooBar::PUB_SETTER_MASK, 0b11100u32);
+        assert_eq!(FooBar::PUB_GETTER_MASK, 0b1110u32);
         assert_eq!(FooBar::SINGLE_BIT_MASK, 1 << 3);
+        assert_eq!(FooBar::PUB_MASK, 1 << 31);
     }
 }


### PR DESCRIPTION
Closes #38 

Declarative macros are a bit weird. I'm using a constant name rather than `_` because `_` is not matched as an identifier, so making it `_` would doubling the number of rules.

The type is defined for the mask differently than for the setters/getters because:
- the type needs to be a number literal for the const logic to work
- Custom types for the getter/setters are sometimes wrappers around the values with `From/Into` implemented, and the types used there don't make sense as masks.