### PR TITLE
Fix typo causing expansion fail

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ macro_rules! bitfield_fields {
 
     (only $only:tt; $default_ty:ty; ($(#[$attribute:meta])*) $t:ty, mask $mask:ident($mask_t:ty), from into $into:ty, $getter:tt, $setter:tt:
      $($exprs:expr),*; $($rest:tt)*) => {
-        bitfield_fields!{only $only; @field $(#[$attribute])* () $t, $mask($mask_ty), $into, $into, $getter, $setter: $($exprs),*}
+        bitfield_fields!{only $only; @field $(#[$attribute])* () $t, $mask($mask_t), $into, $into, $getter, $setter: $($exprs),*}
         bitfield_fields!{only $only; $default_ty; $($rest)*}
     };
 


### PR DESCRIPTION
This patch fixes a typo where `$mask_ty` is used and the capture is actually `$mask_t`.