### PR TITLE
Easily Derive Bitwise Operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,34 @@ macro_rules! bitfield_impl {
             bitfield_debug!{struct $name; $($rest)*}
         }
     };
+    (BitAnd for struct $name:ident($t:ty); $($rest:tt)*) => {
+        impl $crate::ops::BitAnd for $name {
+            type Output = Self;
+            fn bitand(self, rhs: Self) -> Self {
+                Self(self.0 & rhs.0)
+            }
+        }
+    };
+    (BitOr for struct $name:ident($t:ty); $($rest:tt)*) => {
+        impl $crate::ops::BitOr for $name {
+            type Output = Self;
+            fn bitor(self, rhs: Self) -> Self {
+                Self(self.0 | rhs.0)
+            }
+        }
+    };
+    (BitXor for struct $name:ident($t:ty); $($rest:tt)*) => {
+        impl $crate::ops::BitXor for $name {
+            type Output = Self;
+            fn bitxor(self, rhs: Self) -> Self {
+                Self(self.0 ^ rhs.0)
+            }
+        }
+    };
     // display a more friendly error message when someone tries to use `impl <Trait>;` syntax when not supported
     ($macro:ident for struct $name:ident $($rest:tt)*) => {
         ::std::compile_error!(::std::stringify!(Unsupported impl $macro for struct $name));
-    }
+    };
 }
 
 /// Declares the fields of struct.
@@ -724,6 +748,8 @@ pub use core::convert::Into;
 pub use core::fmt;
 #[doc(hidden)]
 pub use core::mem::size_of;
+#[doc(hidden)]
+pub use core::ops;
 
 /// A trait to get ranges of bits.
 pub trait BitRange<T> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -213,6 +213,12 @@ fn test_bitwise_ops() {
     assert!(ffxor.b());
     assert!(ffxor.c());
     assert!(!ffxor.d());
+
+    ff1 ^= ff2;
+    assert!(!ff1.a());
+    assert!(ff1.b());
+    assert!(ff1.c());
+    assert!(!ff1.d());
 }
 
 #[test]
@@ -797,7 +803,7 @@ fn test_arraybitfield_msb0() {
 
 #[test]
 fn test_arraybitfield_bitops() {
-    let a = ArrayBitfield([1u8; 3]);
+    let mut a = ArrayBitfield([1u8; 3]);
     let b = ArrayBitfield([1u8, 2u8, 4u8]);
 
     let c = a | b;
@@ -808,6 +814,9 @@ fn test_arraybitfield_bitops() {
 
     let e = a ^ b;
     assert_eq!(e.0, [0, 3, 5]);
+
+    a ^= b;
+    assert_eq!(a.0, [0, 3, 5]);
 }
 
 mod some_module {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -518,7 +518,11 @@ fn test_debug() {
 }
 
 bitfield! {
+    #[derive(Clone, Copy)]
     struct ArrayBitfield([u8]);
+    impl BitAnd;
+    impl BitOr;
+    impl BitXor;
     u32;
     foo1, set_foo1: 0, 0;
     foo2, set_foo2: 7, 0;
@@ -789,6 +793,21 @@ fn test_arraybitfield_msb0() {
     ab.set_signed_foo3(0);
     ab.set_signed_foo4(-1);
     assert_eq!([0x0F, 0xFF, 0xF0], ab.0);
+}
+
+#[test]
+fn test_arraybitfield_bitops() {
+    let a = ArrayBitfield([1u8; 3]);
+    let b = ArrayBitfield([1u8, 2u8, 4u8]);
+
+    let c = a | b;
+    assert_eq!(c.0, [1, 3, 5]);
+
+    let d = a & b;
+    assert_eq!(d.0, [1, 0, 0]);
+
+    let e = a ^ b;
+    assert_eq!(e.0, [0, 3, 5]);
 }
 
 mod some_module {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -27,6 +27,7 @@ bitfield! {
     /// documentation comments also work!
     struct FooBar(u32);
     impl Debug;
+    impl BitOr;
     foo1, set_foo1: 0, 0;
     u8;
     foo2, set_foo2: 31, 31;
@@ -172,6 +173,46 @@ fn test_multiple_bit() {
     assert_eq!(0xF000_000A, fb.0);
     assert_eq!(0xA, fb.foo3());
     assert_eq!(0xF, fb.foo4());
+}
+
+#[test]
+fn test_bitwise_ops() {
+    bitfield! {
+        #[derive(Clone, Copy)]
+        struct FourFields(u8);
+        impl BitOr;
+        impl BitAnd;
+        impl BitXor;
+        a, set_a: 0;
+        b, set_b: 1;
+        c, set_c: 2;
+        d, set_d: 3;
+    }
+
+    let mut ff1 = FourFields(0);
+    ff1.set_a(true);
+    ff1.set_b(true);
+    let mut ff2 = FourFields(0);
+    ff2.set_a(true);
+    ff2.set_c(true);
+
+    let ffand = ff1 & ff2;
+    assert!(ffand.a());
+    assert!(!ffand.b());
+    assert!(!ffand.c());
+    assert!(!ffand.d());
+
+    let ffor = ff1 | ff2;
+    assert!(ffor.a());
+    assert!(ffor.b());
+    assert!(ffor.c());
+    assert!(!ffor.d());
+
+    let ffxor = ff1 ^ ff2;
+    assert!(!ffxor.a());
+    assert!(ffxor.b());
+    assert!(ffxor.c());
+    assert!(!ffxor.d());
 }
 
 #[test]


### PR DESCRIPTION
This pull request will extend the macro syntax with optional lines of the form `impl BitOr;` to generate basic implementations for the common bitwise operators.