### PR TITLE
Generate Constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,12 +133,12 @@ macro_rules! bitfield_impl {
     }};
     (new for struct $name:ident([$t:ty]); $($rest:tt)*) => {
         impl<T: AsMut<[$t]> + Default> $name<T> {
-            bitfield_constructor!{T::default(); () -> {}; $($rest)*}
+            bitfield_constructor!{() -> {}; $($rest)*}
         }
     };
     (new for struct $name:ident($t:ty); $($rest:tt)*) => {
         impl $name {
-            bitfield_constructor!{0; () -> {}; $($rest)*}
+            bitfield_constructor!{() -> {}; $($rest)*}
         }
     };
     (new{$new:ident ($($setter_name:ident: $setter_type:ty),*$(,)?)} for struct $name:ident([$t:ty]); $($rest:tt)*) => {
@@ -620,8 +620,8 @@ macro_rules! bitfield_debug {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! bitfield_constructor {
-    ($zero:expr; () -> {}; $($rest:tt)*) => {
-        bitfield_constructor!{@value; () -> {let mut value = Self($zero);}; bool; $($rest)*}
+    (() -> {}; $($rest:tt)*) => {
+        bitfield_constructor!{@value; () -> {let mut value = Self(Default::default());}; bool; $($rest)*}
     };
     (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $old_ty:ty; impl $_trait:ident$({$($trait_arg:tt)*})?; $($rest:tt)*) => {
         bitfield_constructor!{@$value; ($($param: $ty,)*) -> {$($stmt;)*}; $old_ty; $($rest)*}
@@ -792,6 +792,8 @@ macro_rules! bitfield_bitrange {
 /// The second optional element is a set of lines of the form `impl <Trait>;`. The following traits are supported:
 /// * `Debug`; This will generate an implementation of `fmt::Debug` with the `bitfield_debug` macro.
 /// * `BitAnd`, `BitOr`, `BitXor`; These will generate implementations of the relevant `ops::Bit___` and `ops::Bit___Assign` traits.
+/// * `new`; This will generate a constructor that calls all of the bitfield's setter methods with an argument of the appropriate type
+/// * `new{constructor_name(setter_name: setter_type, ...)}`; This will generate a constructor that calls a given subset of the bitfield's setter methods
 ///
 /// The difference with calling those macros separately is that `bitfield_fields` is called
 /// from an appropriate `impl` block. If you use the non-slice form of `bitfield_bitrange`, the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ macro_rules! bitfield_impl {
     (new{$new:ident ($($setter_name:ident: $setter_type:ty),*$(,)?)} for struct $name:ident($t:ty); $($rest:tt)*) => {
         impl $name {
             pub fn $new($($setter_name: $setter_type),*) -> Self {
-                let mut value = Self(0);
+                let mut value = Self($t::default());
                 $(
                     value.$setter_name($setter_name);
                 )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@
 /// * BitAnd
 /// * BitOr
 /// * BitXor
+///
+/// Additional derivations:
+/// * new
+///   * Creates a constructor, including parameters for all fields with a setter
 #[macro_export(local_inner_macros)]
 macro_rules! bitfield_impl {
     (Debug for struct $name:ident([$t:ty]); $($rest:tt)*) => {
@@ -124,6 +128,16 @@ macro_rules! bitfield_impl {
             $self.0[i] $op $rhs.0[i];
         }
     }};
+    (new for struct $name:ident([$t:ty]); $($rest:tt)*) => {
+        impl<T: AsMut<[$t]> + Default> $name<T> {
+            bitfield_constructor!{T::default(); () -> {}; $($rest)*}
+        }
+    };
+    (new for struct $name:ident($t:ty); $($rest:tt)*) => {
+        impl $name {
+            bitfield_constructor!{0; () -> {}; $($rest)*}
+        }
+    };
     // display a more friendly error message when someone tries to use `impl <Trait>;` syntax when not supported
     ($macro:ident for struct $name:ident $($rest:tt)*) => {
         ::std::compile_error!(::std::stringify!(Unsupported impl $macro for struct $name));
@@ -561,6 +575,38 @@ macro_rules! bitfield_debug {
         bitfield_debug!{$debug_struct, $self, $($rest)*}
     };
     ($debug_struct:ident, $self:ident, ) => {};
+}
+
+/// Implements a constructor function for a bitfield
+#[macro_export(local_inner_macros)]
+macro_rules! bitfield_constructor {
+    ($zero:expr; () -> {}; $($rest:tt)*) => {
+        bitfield_constructor!{@value; () -> {let mut value = Self($zero);}; bool; $($rest)*}
+    };
+    (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $old_ty:ty; $new_ty:ty; $($rest:tt)*) => {
+        bitfield_constructor!{@$value; ($($param: $ty,)*) -> {$($stmt;)*}; $new_ty; $($rest)*}
+    };
+    (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $default_ty:ty;
+    $(#[$_:meta])* $(pub)? $(into $_into:ty,)?
+    $_getter:ident, $setter:ident: $($_expr:expr),*; $($rest:tt)* ) => {
+        bitfield_constructor!{@$value;
+            ($($param: $ty,)* $setter: $default_ty,) -> {$($stmt;)* $value.$setter($setter);};
+            $default_ty; $($rest)*}
+    };
+    (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $default_ty:ty;
+    $(#[$_:meta])* $(pub)? $field_type:ty, $(into $_into:ty,)?
+    $_getter:ident, $setter:ident: $($_expr:expr),*; $($rest:tt)* ) => {
+        bitfield_constructor!{@$value;
+            ($($param: $ty,)* $setter: $field_type,) -> {$($stmt;)* $value.$setter($setter);};
+            $default_ty; $($rest)*}
+    };
+    (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $_:ty;) => {
+        #[allow(clippy::too_many_arguments)]
+        fn new($($param: $ty),*) -> Self {
+            $($stmt;)*
+            $value
+        }
+    }
 }
 
 /// Implements `BitRange` and `BitRangeMut` for a tuple struct (or "newtype").

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@
 /// Additional derivations:
 /// * new
 ///   * Creates a constructor, including parameters for all fields with a setter
+/// * new{constructor_name(setter_name: setter_type, ...)}
+///   * Creates a constructor using the given name and parameters. In order to compile correctly, each `setter_name`
+///     must be the setter of a field of type `setter_type` specified later in the macro.
 #[macro_export(local_inner_macros)]
 macro_rules! bitfield_impl {
     (Debug for struct $name:ident([$t:ty]); $($rest:tt)*) => {
@@ -136,6 +139,28 @@ macro_rules! bitfield_impl {
     (new for struct $name:ident($t:ty); $($rest:tt)*) => {
         impl $name {
             bitfield_constructor!{0; () -> {}; $($rest)*}
+        }
+    };
+    (new{$new:ident ($($setter_name:ident: $setter_type:ty),*$(,)?)} for struct $name:ident([$t:ty]); $($rest:tt)*) => {
+        impl<T: AsMut<[$t]> + Default> $name<T> {
+            pub fn $new($($setter_name: $setter_type),*) -> Self {
+                let mut value = Self(T::default());
+                $(
+                    value.$setter_name($setter_name);
+                )*
+                value
+            }
+        }
+    };
+    (new{$new:ident ($($setter_name:ident: $setter_type:ty),*$(,)?)} for struct $name:ident($t:ty); $($rest:tt)*) => {
+        impl $name {
+            pub fn $new($($setter_name: $setter_type),*) -> Self {
+                let mut value = Self(0);
+                $(
+                    value.$setter_name($setter_name);
+                )*
+                value
+            }
         }
     };
     // display a more friendly error message when someone tries to use `impl <Trait>;` syntax when not supported
@@ -577,11 +602,29 @@ macro_rules! bitfield_debug {
     ($debug_struct:ident, $self:ident, ) => {};
 }
 
-/// Implements a constructor function for a bitfield
+/// Implements an exhaustive constructor function for a bitfield. Should only be called by `bitfield!` when using `impl new;`
+///
+/// # Examples
+///
+/// ```rs
+/// bitfield_constructor {0; () -> {}; u8; foo1, set_foo1: 2,0; foo2, set_foo2: 7,2}
+/// ```
+/// Generates:
+/// ```rs
+/// pub fn new(set_foo1: u8, set_foo2: u8) -> Self {
+///     let mut value = Self(0);
+///     value.set_foo1(set_foo1);
+///     value.set_foo2(set_foo2);
+///     value
+/// }
+/// ```
 #[macro_export(local_inner_macros)]
 macro_rules! bitfield_constructor {
     ($zero:expr; () -> {}; $($rest:tt)*) => {
         bitfield_constructor!{@value; () -> {let mut value = Self($zero);}; bool; $($rest)*}
+    };
+    (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $old_ty:ty; impl $_trait:ident$({$($trait_arg:tt)*})?; $($rest:tt)*) => {
+        bitfield_constructor!{@$value; ($($param: $ty,)*) -> {$($stmt;)*}; $old_ty; $($rest)*}
     };
     (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $old_ty:ty; $new_ty:ty; $($rest:tt)*) => {
         bitfield_constructor!{@$value; ($($param: $ty,)*) -> {$($stmt;)*}; $new_ty; $($rest)*}
@@ -602,11 +645,11 @@ macro_rules! bitfield_constructor {
     };
     (@$value:ident; ($($param:ident: $ty:ty,)*) -> {$($stmt:stmt;)*}; $_:ty;) => {
         #[allow(clippy::too_many_arguments)]
-        fn new($($param: $ty),*) -> Self {
+        pub fn new($($param: $ty),*) -> Self {
             $($stmt;)*
             $value
         }
-    }
+    };
 }
 
 /// Implements `BitRange` and `BitRangeMut` for a tuple struct (or "newtype").
@@ -807,14 +850,14 @@ macro_rules! bitfield {
     };
     // Force `impl <Trait>` to always be after `no default BitRange` it the two are present.
     // This simplify the rest of the macro.
-    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident($($type:tt)*); $(impl $trait:ident;)+ no default BitRange; $($rest:tt)*) => {
-         bitfield!{$(#[$attribute])* ($($vis)*) struct $name($($type)*); no default BitRange; $(impl $trait;)* $($rest)*}
+    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident($($type:tt)*); $(impl $trait:ident$({$($trait_arg:tt)*})?;)+ no default BitRange; $($rest:tt)*) => {
+         bitfield!{$(#[$attribute])* ($($vis)*) struct $name($($type)*); no default BitRange; $(impl $trait$({$($trait_arg)*})?;)* $($rest)*}
      };
 
     // If we have `impl <Trait>` without `no default BitRange`, we will still match, because when
     // we call `bitfield_bitrange`, we add `no default BitRange`.
-    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident([$t:ty]); no default BitRange; impl $trait:ident; $($rest:tt)*) => {
-        bitfield_impl!{$trait for struct $name([$t]); $($rest)*}
+    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident([$t:ty]); no default BitRange; impl $trait:ident$({$($trait_arg:tt)*})?; $($rest:tt)*) => {
+        bitfield_impl!{$trait$({$($trait_arg)*})? for struct $name([$t]); $($rest)*}
 
         bitfield!{$(#[$attribute])* ($($vis)*) struct $name([$t]); no default BitRange;  $($rest)*}
     };
@@ -847,8 +890,8 @@ macro_rules! bitfield {
         bitfield!{$(#[$attribute])* ($($vis)*) struct $name([$t]); no default BitRange; $($rest)*}
     };
 
-    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident($t:ty); no default BitRange; impl $trait:ident; $($rest:tt)*) => {
-        bitfield_impl!{$trait for struct $name($t); $($rest)*}
+    ($(#[$attribute:meta])* ($($vis:tt)*) struct $name:ident($t:ty); no default BitRange; impl $trait:ident$({$($trait_arg:tt)*})?; $($rest:tt)*) => {
+        bitfield_impl!{$trait$({$($trait_arg)*})? for struct $name($t); $($rest)*}
 
         bitfield!{$(#[$attribute])* ($($vis)*) struct $name($t); no default BitRange; $($rest)*}
     };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -175,20 +175,21 @@ fn test_multiple_bit() {
     assert_eq!(0xF, fb.foo4());
 }
 
+bitfield! {
+    #[derive(Clone, Copy)]
+    struct FourFields(u8);
+    impl BitOr;
+    impl BitAnd;
+    impl BitXor;
+    impl new;
+    a, set_a: 0;
+    b, set_b: 1;
+    c, set_c: 2;
+    d, set_d: 3;
+}
+
 #[test]
 fn test_bitwise_ops() {
-    bitfield! {
-        #[derive(Clone, Copy)]
-        struct FourFields(u8);
-        impl BitOr;
-        impl BitAnd;
-        impl BitXor;
-        a, set_a: 0;
-        b, set_b: 1;
-        c, set_c: 2;
-        d, set_d: 3;
-    }
-
     let mut ff1 = FourFields(0);
     ff1.set_a(true);
     ff1.set_b(true);
@@ -217,6 +218,15 @@ fn test_bitwise_ops() {
     ff1 ^= ff2;
     assert!(!ff1.a());
     assert!(ff1.b());
+    assert!(ff1.c());
+    assert!(!ff1.d());
+}
+
+#[test]
+fn test_constructor() {
+    let ff1 = FourFields::new(true, false, true, false);
+    assert!(ff1.a());
+    assert!(!ff1.b());
     assert!(ff1.c());
     assert!(!ff1.d());
 }
@@ -529,6 +539,7 @@ bitfield! {
     impl BitAnd;
     impl BitOr;
     impl BitXor;
+    impl new;
     u32;
     foo1, set_foo1: 0, 0;
     foo2, set_foo2: 7, 0;
@@ -817,6 +828,16 @@ fn test_arraybitfield_bitops() {
 
     a ^= b;
     assert_eq!(a.0, [0, 3, 5]);
+}
+
+#[test]
+fn test_arraybitfield_constructor() {
+    let a: ArrayBitfield<[u8; 3]> = ArrayBitfield::new(1, 2, 3, 4, -1, -2, -3, -4, 0b0001_0000);
+    println!("{:b}", a.0[0]);
+    assert_eq!(a.foo1(), 0);
+    assert_eq!(a.foo2(), 10);
+    assert_eq!(a.foo3(), 133);
+    assert_eq!(a.foo4(), 16);
 }
 
 mod some_module {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -540,6 +540,8 @@ bitfield! {
     impl BitOr;
     impl BitXor;
     impl new;
+    impl new{foo_unsigned (set_foo1: u32, set_foo2: u32, set_foo3: u32, set_foo4: u32)};
+    impl new{foo_signed (set_signed_foo1: i32, set_signed_foo2: i32, set_signed_foo3: i32, set_signed_foo4: i32)};
     u32;
     foo1, set_foo1: 0, 0;
     foo2, set_foo2: 7, 0;
@@ -838,6 +840,12 @@ fn test_arraybitfield_constructor() {
     assert_eq!(a.foo2(), 10);
     assert_eq!(a.foo3(), 133);
     assert_eq!(a.foo4(), 16);
+
+    let b: ArrayBitfield<[u8; 3]> = ArrayBitfield::foo_unsigned(1, 4, 6, u32::MAX);
+    assert_eq!(b.signed_foo1(), 0);
+    assert_eq!(b.signed_foo2(), -4);
+    assert_eq!(b.signed_foo3(), -2);
+    assert_eq!(b.signed_foo4(), -1);
 }
 
 mod some_module {


### PR DESCRIPTION
As of this writing, using `impl new;` creates a constructor with parameters and calls for all setters. Using `impl new {func_name(setter: ty, ...);` creates a constructor called `func_name` with the specified arguments that calls setters with the given type.

Ideally I'd want to use the names of the getters as function parameters, since those are generally a better representation of what the field is, and I'd like to grab the types from the field definition as well. However, unless there's a good way to check if two identifiers are the same, this seems impossible to do without procedural macros

Originally #18 