### PR TITLE
Implement Bitwise Operations for All Array-Like Types

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -817,6 +817,21 @@ fn test_arraybitfield_bitops() {
 
     a ^= b;
     assert_eq!(a.0, [0, 3, 5]);
+
+    let mut vec_a = ArrayBitfield(vec![1u8; 3]);
+    let vec_b = ArrayBitfield(vec![1u8, 2u8, 4u8]);
+
+    let vec_c = vec_a.clone() | vec_b.clone();
+    assert_eq!(vec_c.0, [1, 3, 5]);
+
+    let vec_d = vec_a.clone() & vec_b.clone();
+    assert_eq!(vec_d.0, [1, 0, 0]);
+
+    let vec_e = vec_a.clone() ^ vec_b.clone();
+    assert_eq!(vec_e.0, [0, 3, 5]);
+
+    vec_a ^= vec_b;
+    assert_eq!(vec_a.0, [0, 3, 5]);
 }
 
 mod some_module {


### PR DESCRIPTION
When adding bitwise operations to the array types, I didn't realize how easy it would be to use the `AsMut` and `AsRef` traits. Instead, I only implemented it for arrays of the form `[uX; N]`. This PR adds bitwise operations for all supported types, most notably including including `Vec`.

I'm not particularly familiar with semver, but if this ends up as a feature on its own, I think it could be considered a patch; the only API surface change is that these `impl`s now work with a couple more types.