### PR TITLE
Allow usage of a signed int types for the base of newtype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,3 +478,5 @@ macro_rules! impl_bitrange_for_u_combinations {
 
 impl_bitrange_for_u_combinations! {(u8, u16, u32, u64, u128), (u8, u16, u32, u64, u128)}
 impl_bitrange_for_u_combinations! {(u8, u16, u32, u64, u128), (i8, i16, i32, i64, i128)}
+impl_bitrange_for_u_combinations! {(i8, i16, i32, i64, i128), (u8, u16, u32, u64, u128)}
+impl_bitrange_for_u_combinations! {(i8, i16, i32, i64, i128), (i8, i16, i32, i64, i128)}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1306,3 +1306,43 @@ pub mod deny_missing_docs {
         pub field1, set_field1: 0;
     }
 }
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    /// documentation comments also work!
+    struct FooBarSigned(i32);
+    impl Debug;
+    impl BitOr;
+    foo1, set_foo1: 31, 8;
+    foo2, set_foo2: 10, 10, 2;
+    mask A_MASK(u32), foo3, set_foo3: 3, 1;
+    u8;
+    foo4, set_foo4: THREE, 0;
+    u32, foo5, set_foo5: 31,8;
+}
+
+#[test]
+fn field_type_signed() {
+    let fbs = FooBarSigned(0);
+    let _: i32 = fbs.foo1();
+    let _: i32 = fbs.foo2(0);
+    let _: i32 = fbs.foo3();
+    let _: u8 = fbs.foo4();
+    let _: u32 = fbs.foo5();
+}
+
+#[test]
+fn value_signed() {
+    let initial_value = 0b1101_0101_1010_1010_1010_1010_0110_0010u32 as i32;
+    let fbs = FooBarSigned(initial_value);
+    assert_eq!(
+        fbs.foo1(),
+        0b1111_1111_1101_0101_1010_1010_1010_1010u32 as i32
+    );
+    assert_eq!(fbs.foo5(), 0b1101_0101_1010_1010_1010_1010u32);
+}
+
+#[test]
+fn mask_signed() {
+    assert_eq!(FooBarSigned::A_MASK, 0b1110u32);
+}


### PR DESCRIPTION
Currently, you can't use any of the signed types as a base of bitfield struct:
```
error[E0599]: the method `set_bit_range` exists for mutable reference `&mut TestBitfield`, but its trait bounds were not satisfied
  --> src\main.rs:6:1
   |
6  | / bitfield! {
7  | |     #[derive(Copy, Clone, PartialEq, Eq)]
8  | |     pub struct TestBitfield(i32);
9  | |     impl Debug;
...  |
19 | |     _, set_category: 31, 28;
20 | | }
   | |_^ method cannot be called on `&mut TestBitfield` due to unsatisfied trait bounds
```
this pr fixes this issue