### PR TITLE
Add license files to bitfield-macros

### DIFF
--- a/bitfield-macros/LICENSE-APACHE
+++ b/bitfield-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/bitfield-macros/LICENSE-MIT
+++ b/bitfield-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This makes sure that the next time `bitfield-macros` is published it will include the `LICENSE-APACHE` and `LICENSE-MIT` files.