### PR TITLE
chore(bitfield-macros): bump `syn` to v3

### DIFF
--- a/bitfield-macros/Cargo.toml
+++ b/bitfield-macros/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
-syn = "2.0.96"
+syn = "3.0"


### PR DESCRIPTION
Following the [release of a new major version of `syn`](https://github.com/dtolnay/syn/releases/tag/3.0.0), this bumps the version used by `bitfield-macros`, with the goal of eventually removing the duplicated dependency in binaries (and therefore reducing compile times).

`syn` still advertises [the same MSRV of 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14), so this shouldn't affect the MSRV of this crate.

`syn` v3 of course contains breaking changes: I went through the changelog but didn't find anything relevant (but there are quite a few of them so I could have missed some). I've run `cargo test` but didn't do any other kind of testing.