### PR TITLE
style: remove trailing whitespace to allow `cargo fmt`ing

### DIFF
--- a/bitfield-macros/src/lib.rs
+++ b/bitfield-macros/src/lib.rs
@@ -474,7 +474,7 @@ fn generate_getters(fields: &[BitfieldField]) -> proc_macro2::TokenStream {
                         let ty_into = field.ty_into().unwrap();
                         let (return_ty, last_line) = if field.try_into {
                             (
-                                quote!{Result<#ty_into, <#ty_into as TryFrom<#ty>>::Error>}, 
+                                quote!{Result<#ty_into, <#ty_into as TryFrom<#ty>>::Error>},
                                 quote!{::bitfield::TryInto::try_into(raw_value)}
                             )
                         } else {


### PR DESCRIPTION
This simply removes a trailing space so `cargo fmt` can run. I otherwise get the following error:

```sh
error[internal]: left behind trailing whitespace
   --> [redacted]/rust-bitfield/bitfield-macros/src/lib.rs:477:477:93
    |
477 | ...                   quote!{Result<#ty_into, <#ty_into as TryFrom<#ty>>::Error>}, 
    |                                                                                   ^
    |

warning: rustfmt has failed to format. See previous 1 errors.
```