### PR TITLE
refactor: box some enum variants to spare the stack

### DIFF
--- a/bitfield-macros/src/lib.rs
+++ b/bitfield-macros/src/lib.rs
@@ -67,7 +67,7 @@ impl Parse for BitfieldPosition {
 
 enum FieldTy {
     Bool,
-    Type(Type),
+    Type(Box<Type>),
     None,
 }
 
@@ -75,7 +75,7 @@ impl FieldTy {
     fn as_type(&self) -> Option<Type> {
         match self {
             FieldTy::Bool => Some(syn::parse_str("bool").unwrap()),
-            FieldTy::Type(ty) => Some(ty.clone()),
+            FieldTy::Type(ty) => Some(*ty.clone()),
             FieldTy::None => None,
         }
     }
@@ -85,8 +85,8 @@ impl FieldTy {
     }
 }
 
-impl From<Option<Type>> for FieldTy {
-    fn from(value: Option<Type>) -> Self {
+impl From<Option<Box<Type>>> for FieldTy {
+    fn from(value: Option<Box<Type>>) -> Self {
         match value {
             Some(ty) => FieldTy::Type(ty),
             None => FieldTy::None,
@@ -201,8 +201,8 @@ impl Parse for BitfieldField {
 }
 
 enum BitfieldFieldLine {
-    NewDefaultType(Type),
-    Field(BitfieldField),
+    NewDefaultType(Box<Type>),
+    Field(Box<BitfieldField>),
 }
 
 impl Parse for BitfieldFieldLine {
@@ -234,7 +234,7 @@ impl BitfieldFieldLines {
                     if field.ty.is_none() {
                         field.ty = default_ty.clone().into();
                     }
-                    result.push(field)
+                    result.push(*field)
                 }
             }
         }


### PR DESCRIPTION
As suggested by Clippy, this proposes to box some enum variants:

```sh
warning: large size difference between variants
  --> bitfield-macros/src/lib.rs:68:1
   |
68 | / enum FieldTy {
69 | |     Bool,
   | |     ---- the second-largest variant carries no data at all
70 | |     Type(Type),
   | |     ---------- the largest variant contains at least 224 bytes
71 | |     None,
72 | | }
   | |_^ the entire enum is at least 224 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#large_enum_variant
   = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   |
70 -     Type(Type),
70 +     Type(Box<Type>),
   |

warning: large size difference between variants
   --> bitfield-macros/src/lib.rs:203:1
    |
203 | / enum BitfieldFieldLine {
204 | |     NewDefaultType(Type),
    | |     -------------------- the second-largest variant contains at least 224 bytes
205 | |     Field(BitfieldField),
    | |     -------------------- the largest variant contains at least 1312 bytes
206 | | }
    | |_^ the entire enum is at least 1312 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#large_enum_variant
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
205 -     Field(BitfieldField),
205 +     Field(Box<BitfieldField>),
    |
```

This is also ever more useful with #66, as the sizes of `FieldTy` and `BitfieldFieldLine` then increase to 248 bytes and 1384 bytes respectively, as measured by Clippy.

`cargo test` still passes as expected.