### PR TITLE
fix: use assert! instead of debug_assert! in check_msb_lsb_order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@
 
 pub use bitfield_macros::{bitfield_constructor, bitfield_debug, bitfield_fields};
 
-/// Internal use macro, that `debug_assert` than msb >= lsb and thus they are not inverted
+/// Internal use macro, that asserts that msb >= lsb and thus they are not inverted
 #[macro_export]
 macro_rules! check_msb_lsb_order {
     ($msb:expr, $lsb:expr) => {
-        debug_assert!(
+        assert!(
             $msb >= $lsb,
             "the MSB ({}) is smaller than the LSB ({}), you likely inverted them",
             $msb,


### PR DESCRIPTION
## Summary

- Replace `debug_assert!` with `assert!` in `check_msb_lsb_order!` macro so MSB/LSB inversion is always caught, not just in debug builds

Fixes #69

## Test plan

- [x] `cargo test` passes (debug mode — 45 tests)
- [x] `cargo test --release` passes (release mode — 45 tests, including the 12 `#[should_panic]` tests that previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)